### PR TITLE
Add support for Git::Hooks 2.0.0

### DIFF
--- a/lib/Git/Hooks/PerlCritic.pm
+++ b/lib/Git/Hooks/PerlCritic.pm
@@ -14,7 +14,7 @@ sub _changed {
 
 	my @changed
 		= grep { /\.(p[lm]|t)$/xms }
-		$git->command( qw/diff --cached --name-only --diff-filter=AM/ )
+		$git->filter_files_in_index( 'AM' )
 		;
 
 	return \@changed;


### PR DESCRIPTION
I just released a TRIAL version 2.0.0 of Git::Hooks which introduces some incompatible changes.

I think your plugin needs just a small change to make it compatible with any version of Git::Hooks. I haven't tested it though...